### PR TITLE
Fix minor typo in URI scheme syntax header

### DIFF
--- a/draft-zundel-spice-glue-id.md
+++ b/draft-zundel-spice-glue-id.md
@@ -92,7 +92,7 @@ of the glue URI Authority Identifier registry. The External Number MUST be the
 identifier assigned to the company by the external authority under the
 identified scheme.
 
-## glue URI Sceme Text Syntax
+## glue URI Scheme Text Syntax
 
 TODO ABNF
 


### PR DESCRIPTION
Looks good, so far, but it is hard to ignore once I saw it. 😄 