### PR TITLE
Add privacy considerations around private IDs in glue URIs

### DIFF
--- a/draft-zundel-spice-glue-id.md
+++ b/draft-zundel-spice-glue-id.md
@@ -122,9 +122,12 @@ It is possible for such identifers to be represented as glue URIs. An
 identifier's expression as a glue URI does not change the privacy
 characteristics of that identifier. The same cautions and concerns need to be
 taken with the glue URI representation as with the original identifier.
+
 Implementers storing or evaluating glue ids are encouraged to evaluate the
-privacy characteristics of each identification scheme represented by an authority
-identifier and to appropriately handle any glue id which violates privacy policies.
+privacy characteristics of each identification scheme represented by an
+authority identifier and to appropriately handle any glue id which violates
+privacy policies.
+
 # IANA Considerations
 
 The following sections detail requests to IANA for the creation of a new

--- a/draft-zundel-spice-glue-id.md
+++ b/draft-zundel-spice-glue-id.md
@@ -116,7 +116,7 @@ TODO Security
 There are some corporate identifers which make use of personal identifiers. This
 is the case for registered sole-proprietor businesses in much of the United
 States, where the business identifier may be the same as the
-social-security-number of the business owner. 
+social-security-number of the business owner.
 
 It is possible for such identifers to be represented as glue URIs. An
 identifier's expression as a glue URI does not change the privacy

--- a/draft-zundel-spice-glue-id.md
+++ b/draft-zundel-spice-glue-id.md
@@ -122,7 +122,9 @@ It is possible for such identifers to be represented as glue URIs. An
 identifier's expression as a glue URI does not change the privacy
 characteristics of that identifier. The same cautions and concerns need to be
 taken with the glue URI representation as with the original identifier.
-Implementers storing or evaluating glue ids are encouraged to evaluate the privacy characteristics of each authority potentially represented by authority identifiers and to appropriately handle any glue id whose authority identifier format violates privacy policies.
+Implementers storing or evaluating glue ids are encouraged to evaluate the
+privacy characteristics of each identification scheme represented by an authority
+identifier and to appropriately handle any glue id which violates privacy policies.
 # IANA Considerations
 
 The following sections detail requests to IANA for the creation of a new

--- a/draft-zundel-spice-glue-id.md
+++ b/draft-zundel-spice-glue-id.md
@@ -122,7 +122,7 @@ It is possible for such identifers to be represented as glue URIs. An
 identifier's expression as a glue URI does not change the privacy
 characteristics of that identifier. The same cautions and concerns need to be
 taken with the glue URI representation as with the original identifier.
-
+Implementers storing or evaluating glue ids are encouraged to evaluate the privacy characteristics of each authority potentially represented by authority identifiers and to appropriately handle any glue id whose authority identifier format violates privacy policies.
 # IANA Considerations
 
 The following sections detail requests to IANA for the creation of a new

--- a/draft-zundel-spice-glue-id.md
+++ b/draft-zundel-spice-glue-id.md
@@ -109,6 +109,19 @@ TODO DIDs and glue
 
 TODO Security
 
+# Privacy Considerations
+
+## Private identifiers as corporate identifiers
+
+There are some corporate identifers which make use of personal identifiers. This
+is the case for registered sole-proprietor businesses in much of the United
+States, where the business identifier may be the same as the
+social-security-number of the business owner. 
+
+It is possible for such identifers to be represented as glue URIs. An
+identifier's expression as a glue URI does not change the privacy
+characteristics of that identifier. The same cautions and concerns need to be
+taken with the glue URI representation as with the original identifier.
 
 # IANA Considerations
 


### PR DESCRIPTION
This PR introduces a privacy considerations section, and adds a subsection for considerations when private identifiers are used in corporate identifiers.